### PR TITLE
Better trimming

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,16 +69,15 @@ if an element is found using a fallback strategy it is considered an error, the 
 import config from 'ember-semantic-test-helpers/test-support/config';
 
 config.setErrorLevels({
-  invalidFor: 0
-  perceivedByName: 2
-  myCustomRule: 1
+  invalidFor: 0 //Throw error
+  perceivedByName: 2 //silence
+  myCustomRule: 1 //log to console
 })
 
 ```
-0 = Throw error
-1 = log to console
-2 = silence
 
+Trimming
+------------------------------------------------------------------------------
 
 If you need to build more fallback strategies
 ------------------------------------------------------------------------------

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "eslint-plugin-ember": "^5.0.0",
     "eslint-plugin-node": "^6.0.1",
     "loader.js": "^4.2.3",
-    "semantic-dom-selectors": "^0.0.5"
+    "semantic-dom-selectors": "^0.0.7"
   },
   "engines": {
     "node": "^4.5 || 6.* || >= 7.*"

--- a/tests/integration/components/dom/find-by-aria-test.js
+++ b/tests/integration/components/dom/find-by-aria-test.js
@@ -2,7 +2,8 @@ import { module, test } from 'qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { setupRenderingTest } from 'ember-qunit';
-import { findByAria, buttonQuery } from 'semantic-dom-selectors';
+import { config , buttonQuery } from 'semantic-dom-selectors';
+let findByAria = config.defaultFinders[0].run
 
 module('Integration | Helper | findByAria', function(hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/semantic-finders/trimming-test.js
+++ b/tests/integration/semantic-finders/trimming-test.js
@@ -1,0 +1,21 @@
+import { module, test } from 'qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import { setupRenderingTest } from 'ember-qunit';
+import { findButton } from 'semantic-dom-selectors';
+
+module.only('Integration | Helper | trimming', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it traverses aria-labelledby', async function(assert){
+    await render(hbs`
+      <button id="expected">
+        <h3>Button Title</h3>
+        <p>Description</p>
+      </button>
+    `);
+    let foundButton = findButton('Button Title Description')
+    let expected = document.querySelector("#expected");
+    assert.equal(foundButton, expected);
+  });
+});

--- a/tests/integration/semantic-finders/trimming-test.js
+++ b/tests/integration/semantic-finders/trimming-test.js
@@ -2,12 +2,12 @@ import { module, test } from 'qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { setupRenderingTest } from 'ember-qunit';
-import { findButton } from 'semantic-dom-selectors';
+import { findButton, findControl } from 'semantic-dom-selectors';
 
-module.only('Integration | Helper | trimming', function(hooks) {
+module('Integration | Helper | trimming', function(hooks) {
   setupRenderingTest(hooks);
 
-  test('it traverses aria-labelledby', async function(assert){
+  test('trims nested html tags properly', async function(assert){
     await render(hbs`
       <button id="expected">
         <h3>Button Title</h3>
@@ -17,5 +17,15 @@ module.only('Integration | Helper | trimming', function(hooks) {
     let foundButton = findButton('Button Title Description')
     let expected = document.querySelector("#expected");
     assert.equal(foundButton, expected);
+  });
+
+  test('trims random visual whitespaces properly', async function(assert){
+    await render(hbs`
+      <label for="expected"> asd &nbsp;&nbsp;  <h1>qqq</h1> &#9; &#9; lll</label>
+      <input id="expected"/>
+    `);
+    let found = findControl('asd qqq lll')
+    let expected = document.querySelector("#expected");
+    assert.equal(found, expected);
   });
 });


### PR DESCRIPTION
updates semantic-test-finders that improves trimming add test here since we have not setup testing on other lib for now.

change implemented here https://github.com/tradegecko/semantic-dom-selectors/commit/0da8fbe6477bdee0905d18c1bfa1caef2c6d2fb7#diff-9d9a6cd82f41984872a66a3ab0d440c4L15