### PR TITLE
Remove name from exported function

### DIFF
--- a/addon-test-support/actors/click.js
+++ b/addon-test-support/actors/click.js
@@ -1,5 +1,5 @@
 import baseFiller from './utils/base-filler';
 
-export default async function fillIn(label, value) {
+export default async function(label, value) {
   return await baseFiller(label, value, 'button');
 }

--- a/addon-test-support/actors/fillIn.js
+++ b/addon-test-support/actors/fillIn.js
@@ -1,5 +1,5 @@
 import baseFiller from './utils/base-filler';
 
-export default async function fillIn(label, value) {
+export default async function(label, value) {
   return await baseFiller(label, value, 'text');
 }

--- a/addon-test-support/actors/select.js
+++ b/addon-test-support/actors/select.js
@@ -1,5 +1,5 @@
 import baseFiller from './utils/base-filler';
 
-export default async function fillIn(label, value) {
+export default async function(label, value) {
   await baseFiller(label, value, 'select');
 }

--- a/addon-test-support/actors/toggle.js
+++ b/addon-test-support/actors/toggle.js
@@ -1,5 +1,5 @@
 import baseFiller from './utils/base-filler';
 
-export default async function toggle(label) {
+export default async function(label) {
   return await baseFiller(label, null, 'toggle');
 }


### PR DESCRIPTION
We should clean up the function name by removing them.

*Note: we can renamed these to the correct function name as well. however, i opted for removal instead.*