### PR TITLE
Simplify imports

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,34 +1,14 @@
-'use strict';
-
-
 /* eslint-env node */
 'use strict';
-
-const Funnel = require('broccoli-funnel');
-const MergeTrees = require('broccoli-merge-trees');
 
 module.exports = {
   name: require('./package').name,
 
   included() {
     this._super.included.apply(this, arguments);
-    this.import('vendor/semantic-dom-selectors.js', { type: 'test' });
-    this.import('vendor/qunit-semantic-assertions.js', { type: 'test' });
-  },
-
-  treeForVendor(vendorTree) {
-    let semanticTestHelperTree = new Funnel(`${this.project.root}/node_modules/semantic-dom-selectors/dist`, {
-      files: ['semantic-dom-selectors.js', 'semantic-dom-selectors.js.map'],
-    });
-    let qunitSemanticAssertionsTree = new Funnel(`${this.project.root}/node_modules/qunit-semantic-assertions/dist`, {
-      files: ['qunit-semantic-assertions.js', 'qunit-semantic-assertions.js.map'],
-    });
-    if(vendorTree){
-      //if tree is for app this is not null
-      return new MergeTrees([vendorTree, semanticTestHelperTree, qunitSemanticAssertionsTree]);
-    } else {
-      //if is an addon this is null
-      return new MergeTrees([qunitSemanticAssertionsTree,semanticTestHelperTree]);
-    }
-  },
+    this.import('node_modules/semantic-dom-selectors/dist/semantic-dom-selectors.js', { type: 'test' });
+    this.import('node_modules/semantic-dom-selectors/dist/semantic-dom-selectors.map', { type: 'test' });
+    this.import('node_modules/qunit-semantic-assertions/dist/qunit-semantic-assertions.js', { type: 'test' });
+    this.import('node_modules/qunit-semantic-assertions/dist/qunit-semantic-assertions.map', { type: 'test' });
+  }
 }


### PR DESCRIPTION
When using with [yarn workspaces](https://developer.squareup.com/blog/ember-and-yarn-workspaces/) the `node_modules` folder is actually above the project root, so `this.project.root` will not be able to find the vendor files

Is there a reason for funnelling to vendor before importing?
